### PR TITLE
use [[ to avoid problems with tbl_dfs

### DIFF
--- a/R/countrycode.R
+++ b/R/countrycode.R
@@ -81,8 +81,8 @@ countrycode <- function (sourcevar, origin, destination, warn=FALSE, dictionary=
         sourcefctr <- factor(sourcevar)
 
         # match levels of sourcefctr
-        matchidxs <- match(levels(sourcefctr), dict[, origin])
-        matches <- dict[matchidxs, destination]
+        matchidxs <- match(levels(sourcefctr), dict[[origin]])
+        matches <- dict[[matchidxs, destination]]
 
         # apply new levels to sourcefctr
         destination_vector <- matches[as.numeric(sourcefctr)]


### PR DESCRIPTION
Tibbles (tbl_df) never simplify the result when subsetting even when there is only one column (as normal data frames do). Therefore it's safer to use `[[` which extracts a single, unnamed element whether it's a data frame or a tibble