### PR TITLE
add sanity check for sourcevar

### DIFF
--- a/R/countrycode.R
+++ b/R/countrycode.R
@@ -33,10 +33,13 @@
 #' countrycode(codes.of.origin, "cowc", "iso3c")
 countrycode <- function (sourcevar, origin, destination, warn=FALSE, dictionary=NULL){
     # Sanity check
+    if (missing(sourcevar)) {
+        stop('sourcevar is NULL (does not exist).')
+    }
+    if (! mode(sourcevar) %in% c('character', 'numeric')) {
+        stop('sourcevar must be a character or numeric vector')
+    }
     if(is.null(dictionary)){ # no sanity check if custom dictionary
-        if(is.null(sourcevar)){ 
-            stop("sourcevar is NULL (does not exist).", call. = FALSE)
-        }
         codes = names(countrycode::countrycode_data)
         codes_origin = codes[!codes %in% c("continent","region","regex", "eu28", "ar5")]
         codes_destination = codes[!codes %in% c('regex')]


### PR DESCRIPTION
Do a sanity check on `sourcevar` before anything else. Checks if `sourcevar` is missing, and checks that `sourcevar` is either a character or numeric vector. Fixes issue #83 and provides an appropriate warning if a single column tibble/data.frame is accidentally passed for `sourcevar` as discussed in issue #70.