### PR TITLE
add test against a maintained list of known country variations

### DIFF
--- a/tests/testthat/test-known-name-variations.R
+++ b/tests/testthat/test-known-name-variations.R
@@ -1,0 +1,13 @@
+library(jsonlite)
+
+context('Known country name variations')
+
+variations <- fromJSON('utilities/country_name_known_variations.json')
+
+test_that('correct matches are returned for known country name variations', {
+  match_known <- function(known_variations) countrycode(known_variations, 'country.name', 'country.name')
+
+  for (i in 1:length(variations)) {
+    expect_match(match_known(variations[[i]]), names(variations)[i], all = T)
+  }
+})

--- a/utilities/country_name_known_variations.json
+++ b/utilities/country_name_known_variations.json
@@ -1,0 +1,22 @@
+{
+  "United States of America":[
+    "U.S.A.",
+    "United States",
+    "USA"
+    ],
+  "Republic of Korea":[
+    "South Korea",
+    "Republic of Korea"
+    ],
+  "Democratic People's Republic of Korea":[
+    //"Korea DPR",
+    //"Korea D.P.R.",
+    //"DPR Korea",
+    //"D.P.R. Korea",
+    //"D.P.R Korea",
+    "North Korea",
+    "DPRK",
+    "Democratic People's Republic of Korea",
+    "Korea, Democratic People's Republic"
+    ]
+}


### PR DESCRIPTION
basic infrastructure for maintaining a list of known country name variations which can then be tested against on every build

utilities/country_name_known_variations.json is human-readable and should be easy to maintain and add to as new country name variations are discovered and regexes are improved to match them