### PR TITLE
country.name column no longer exists

### DIFF
--- a/utilities/prep_data.R
+++ b/utilities/prep_data.R
@@ -2,7 +2,7 @@ library(devtools)
 document()
 
 dat = read.csv('data/countrycode_data.csv', stringsAsFactors=FALSE, na.strings=c('', 'NA'))
-dat$iso2c[dat$country.name=='Namibia'] = 'NA'
+dat$iso2c[dat$country.name.en=='Namibia'] = 'NA'
 cn = grep('country.name', colnames(dat))
 for(n in cn){
     dat[, n] = iconv(dat[, n], to='UTF-8')


### PR DESCRIPTION
prep_data.R will now be able to manually fix the NA for Namibia problem again, though I highly suggest saving the CSV with blanks instead of 'NA's, as suggested in #91, to make this manual fix in prep_data.R unnecessary.