### PR TITLE
add custom_match argument feature

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,9 @@ Version 0.19 (????-??-??)
 * Considerably speed up regex conversion by using factors (Thanks to CJ Yetman)
 * countrycode() now includes the "custom_dict" argument, which allows
   user-supplied dictionary data.frames
+* adds a "custom_match" argument, which allows a user-supplied named vector of
+  custom origin->destination matches that will supercede any matching values in
+  the default result (issue #107) (Thanks to @cjyetman)
 * updated tests to new testthat convention (Thanks to CJ Yetman)
 * Modified README to illustrate use of custom dictionaries
 * Added aviation codes (Thanks to Enrico Spinielli)

--- a/man/countrycode.Rd
+++ b/man/countrycode.Rd
@@ -5,7 +5,7 @@
 \title{Convert Country Codes}
 \usage{
 countrycode(sourcevar, origin, destination, warn = TRUE, custom_dict = NULL,
-  origin_regex = FALSE)
+  custom_match = NULL, origin_regex = FALSE)
 }
 \arguments{
 \item{sourcevar}{Vector which contains the codes or country names to be
@@ -29,6 +29,11 @@ Variables correspond to country codes, observations must refer to unique
 countries.  When countrycode uses a user-supplied dictionary, no sanity
 checks are conducted. The data frame format must resemble
 countrycode::countrycode_data.}
+
+\item{custom_match}{A named vector which supplies custom origin and
+destination matches that will supercede any matching default result. The name
+of each element will be used as the origin code, and the value of each
+element will be used as the destination code.}
 
 \item{origin_regex}{Logical: When using a custom dictionary, if TRUE then the
 origin codes will be matched as regex, if FALSE they will be matched exactly.


### PR DESCRIPTION
implements issue #107 

wording in the documentation may need to be improved

also, probably should add some tests for custom matches, for instance...
```r
vector_of_country_names <- c('Germany', 'France', 'Greece', 'United Kingdom')

countrycode(vector_of_country_names, origin = 'country.name', destination = 'iso2c')
# [1] "DE" "FR" "GR" "GB"

custom_match <- c(Greece = 'EL', `United Kingdom` = 'UK')
countrycode(vector_of_country_names, 'country.name', 'iso2c', custom_match = custom_match)
# [1] "DE" "FR" "EL" "UK"
```
and
```r
vector_of_country_names <- c('Germany', 'East Germany', 'South Africa', 'Central and South Africa')

countrycode(vector_of_country_names, 'country.name', 'iso3c')
# [1] "DEU" "DDR" "ZAF" "ZAF"

custom_match <- c(`Central and South Africa` =  NA, `East Germany` = NA)
countrycode(vector_of_country_names, 'country.name', 'iso3c', custom_match = custom_match)
# [1] "DEU" NA    "ZAF" NA
```