### PR TITLE
Fix roxygen formatting for countrycode()

### DIFF
--- a/R/countrycode.R
+++ b/R/countrycode.R
@@ -1,4 +1,4 @@
-# Convert Country Codes
+#' Convert Country Codes
 #'
 #' Converts long country names into one of many different coding schemes.
 #' Translates from one scheme to another. Converts country name or coding

--- a/man/countrycode.Rd
+++ b/man/countrycode.Rd
@@ -2,10 +2,7 @@
 % Please edit documentation in R/countrycode.R
 \name{countrycode}
 \alias{countrycode}
-\title{Converts long country names into one of many different coding schemes.
-Translates from one scheme to another. Converts country name or coding
-scheme to the official short English country name. Creates a new variable
-with the name of the continent or region to which each country belongs.}
+\title{Convert Country Codes}
 \usage{
 countrycode(sourcevar, origin, destination, warn = TRUE, nomatch = NA,
   custom_dict = NULL, custom_match = NULL, origin_regex = FALSE)


### PR DESCRIPTION
This PR fixes the roxygen comment for `countrycode` so that docs aren't formatted like this:

![image](https://user-images.githubusercontent.com/6318931/63537792-99986600-c4e4-11e9-865f-81f585131633.png)
