### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 
 warnings_are_errors: false
 language: r
+r:
+  - oldrel
 cache: packages
 r_binary_packages:
   - devtools


### PR DESCRIPTION
Looks like something in Travis broke because R 4.0.0 was released. Not sure how to test if this change works short of doing a pull request, so  let's see what happens.