### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@
 
 warnings_are_errors: false
 language: r
-r:
-  - oldrel
 cache: packages
 r_binary_packages:
   - devtools


### PR DESCRIPTION
Fixes #221 

DO NOT MERGE NOW. This change will trigger a Travis build that fails until R 4.0.0 is working. The repository owner can restart that build as desired from the Travis build detail screen to check whether it starts working.