### PR TITLE
Trim string to match before applying regex

### DIFF
--- a/R/countrycode.R
+++ b/R/countrycode.R
@@ -168,6 +168,7 @@ countrycode <- function(sourcevar, origin, destination, warn = TRUE, nomatch = N
         # match levels of sourcefctr
         matches <-
           sapply(c(levels(sourcefctr), NA), function(x) { # add NA so there's at least one item
+            x <- trimws(x)
             matchidx <- sapply(dict[[origin]], function(y) grepl(y, x, perl = TRUE, ignore.case = TRUE))
             dict[matchidx, destination]
           })

--- a/tests/testthat/test-regex-special.R
+++ b/tests/testthat/test-regex-special.R
@@ -204,3 +204,8 @@ test_that('Northern Ireland is not Ireland', {
     expect_equal(no_warn_iso3c_of('Northern Ireland'), NA_character_)
     expect_equal(iso3c_of('Ireland'), 'IRL')
 })
+
+test_that('leading and trailing whitespace does not interfere', {
+    expect_equal(cowc_of(' Republic of Vietnam'), 'RVN')
+    expect_equal(cowc_of('\tUnited States'), 'USA')
+})


### PR DESCRIPTION
Is this undesirable for any reason? I can't think of one.

Fixes #207.