### PR TITLE
Enable global roxygen2 Markdown support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,26 +1,38 @@
-Package: countrycode
-License: GPL-3
-Title: Convert Country Names and Country Codes
-LazyData: yes
 Type: Package
-LazyLoad: yes
-Encoding: UTF-8
-Authors@R: c(
-    person("Vincent", "Arel-Bundock", email = "vincent.arel-bundock@umontreal.ca", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-2042-7063")),
-    person("CJ", "Yetman", email = "cj@cjyetman.com", role = "ctb", comment = c(ORCID = "0000-0001-5099-9500")),
-    person("Nils", "Enevoldsen", email = "nils@wlonk.com", role = "ctb", comment = c(ORCID = "0000-0001-7195-4117"))
-    )
-Description: Standardize country names, convert them into one of
-    40 different coding schemes, convert between coding schemes, and
-    assign region descriptors.
+Package: countrycode
+Title: Convert Country Names and Country Codes
 Version: 1.2.0
+Date: 2020-05-22
+Authors@R: 
+    c(person(given = "Vincent",
+             family = "Arel-Bundock",
+             role = c("aut", "cre"),
+             email = "vincent.arel-bundock@umontreal.ca",
+             comment = c(ORCID = "0000-0003-2042-7063")),
+      person(given = "CJ",
+             family = "Yetman",
+             role = "ctb",
+             email = "cj@cjyetman.com",
+             comment = c(ORCID = "0000-0001-5099-9500")),
+      person(given = "Nils",
+             family = "Enevoldsen",
+             role = "ctb",
+             email = "nils@wlonk.com",
+             comment = c(ORCID = "0000-0001-7195-4117")))
+Description: Standardize country names, convert them into one of 40
+    different coding schemes, convert between coding schemes, and assign
+    region descriptors.
+License: GPL-3
 URL: https://vincentarelbundock.github.io/countrycode
 BugReports: https://github.com/vincentarelbundock/countrycode/issues
-Date: 2020-05-22
 Depends:
     R (>= 2.10)
 Suggests:
     testthat,
     tibble,
     utf8
-RoxygenNote: 7.1.1
+Encoding: UTF-8
+LazyData: yes
+LazyLoad: yes
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.1.1.9001

--- a/man/cldr_examples.Rd
+++ b/man/cldr_examples.Rd
@@ -12,8 +12,8 @@ cldr_examples
 }
 \description{
 \itemize{
-  \item Code: CLDR code
-  \item Example: French Southern Territories in different languages
+\item Code: CLDR code
+\item Example: French Southern Territories in different languages
 }
 }
 \keyword{datasets}

--- a/man/codelist.Rd
+++ b/man/codelist.Rd
@@ -8,77 +8,77 @@
 data frame with codes as columns
 }
 \description{
-A data frame used internally by the \code{countrycode()} function. `countrycode` can use any valid code as destination, but only some codes can be used as origin.
+A data frame used internally by the \code{countrycode()} function. \code{countrycode} can use any valid code as destination, but only some codes can be used as origin.
 }
 \details{
 Origin and Destination:
 
 \itemize{
-  \item ccTLD: IANA country code top-level domain
-  \item country.name: country name (English)
-  \item country.name.de: country name (German)
-  \item cowc: Correlates of War character
-  \item cown: Correlates of War numeric
-  \item dhs: Demographic and Health Surveys Program
-  \item ecb: European Central Bank
-  \item eurostat:  Eurostat
-  \item fao: Food and Agriculture Organization of the United Nations numerical code
-  \item fips: FIPS 10-4 (Federal Information Processing Standard)
-  \item gaul: Global Administrative Unit Layers
-  \item genc2c: GENC 2-letter code
-  \item genc3c: GENC 3-letter code
-  \item genc3n: GENC numeric code
-  \item gwc: Gleditsch & Ward character
-  \item gwn: Gleditsch & Ward numeric
-  \item imf: International Monetary Fund
-  \item ioc: International Olympic Committee
-  \item iso2c: ISO-2 character
-  \item iso3c: ISO-3 character
-  \item iso3n: ISO-3 numeric
-  \item p4n: Polity IV numeric country code
-  \item p4c: Polity IV character country code
-  \item un: United Nations M49 numeric codes
-  \item unicode.symbol: Region subtag (often displayed as emoji flag)
-  \item unpd: United Nations Procurement Division
-  \item vdem: Varieties of Democracy (V-Dem version 8, April 2018)
-  \item wb: World Bank (very similar but not identical to iso3c)
-  \item wvs: World Values Survey numeric code
+\item ccTLD: IANA country code top-level domain
+\item country.name: country name (English)
+\item country.name.de: country name (German)
+\item cowc: Correlates of War character
+\item cown: Correlates of War numeric
+\item dhs: Demographic and Health Surveys Program
+\item ecb: European Central Bank
+\item eurostat:  Eurostat
+\item fao: Food and Agriculture Organization of the United Nations numerical code
+\item fips: FIPS 10-4 (Federal Information Processing Standard)
+\item gaul: Global Administrative Unit Layers
+\item genc2c: GENC 2-letter code
+\item genc3c: GENC 3-letter code
+\item genc3n: GENC numeric code
+\item gwc: Gleditsch & Ward character
+\item gwn: Gleditsch & Ward numeric
+\item imf: International Monetary Fund
+\item ioc: International Olympic Committee
+\item iso2c: ISO-2 character
+\item iso3c: ISO-3 character
+\item iso3n: ISO-3 numeric
+\item p4n: Polity IV numeric country code
+\item p4c: Polity IV character country code
+\item un: United Nations M49 numeric codes
+\item unicode.symbol: Region subtag (often displayed as emoji flag)
+\item unpd: United Nations Procurement Division
+\item vdem: Varieties of Democracy (V-Dem version 8, April 2018)
+\item wb: World Bank (very similar but not identical to iso3c)
+\item wvs: World Values Survey numeric code
 }
 Destination only:
 \itemize{
-  \item ar5: IPCC's regional mapping used both in the Fifth Assessment Report
-             (AR5) and for the Reference Concentration Pathways (RCP)
-  \item continent: Continent as defined in the World Bank Development Indicators
-  \item cow.name: Correlates of War country name
-  \item currency: ISO 4217 currency name
-  \item eurocontrol_pru:  European Organisation for the Safety of Air Navigation
-  \item eurocontrol_statfor:  European Organisation for the Safety of Air Navigation
-  \item eu28: Member states of the European Union (as of December 2015),
-              without special territories
-  \item icao.region: International Civil Aviation Organization region
-  \item iso.name.en: ISO English short name
-  \item iso.name.fr: ISO French short name
-  \item iso4217c: ISO 4217 currency alphabetic code
-  \item iso4217n: ISO 4217 currency numeric code
-  \item p4.name: Polity IV country name
-  \item region: 7 Regions as defined in the World Bank Development Indicators
-  \item region23: 23 Regions as used to be in the World Bank Development Indicators (legacy)
-  \item un.name.ar: United Nations Arabic country name
-  \item un.name.en: United Nations English country name
-  \item un.name.es: United Nations Spanish country name
-  \item un.name.fr: United Nations French country name
-  \item un.name.ru: United Nations Russian country name
-  \item un.name.zh: United Nations Chinese country name
-  \item un.region.name: United Nations region name
-  \item un.region.code: United Nations region code
-  \item un.regionintermediate.name: United Nations intermediate region name
-  \item un.regionintermediate.code: United Nations intermediate region code
-  \item un.regionsub.name: United Nations sub-region name
-  \item un.regionsub.code: United Nations sub-region code
-  \item wvs.name: World Values Survey numeric code country name
-  \item cldr.*: 600+ country name variants from the UNICODE CLDR project.
-  Inspect the `countrycode::cldr_examples` data.frame for a full list of
-  available country names and examples.
+\item ar5: IPCC's regional mapping used both in the Fifth Assessment Report
+(AR5) and for the Reference Concentration Pathways (RCP)
+\item continent: Continent as defined in the World Bank Development Indicators
+\item cow.name: Correlates of War country name
+\item currency: ISO 4217 currency name
+\item eurocontrol_pru:  European Organisation for the Safety of Air Navigation
+\item eurocontrol_statfor:  European Organisation for the Safety of Air Navigation
+\item eu28: Member states of the European Union (as of December 2015),
+without special territories
+\item icao.region: International Civil Aviation Organization region
+\item iso.name.en: ISO English short name
+\item iso.name.fr: ISO French short name
+\item iso4217c: ISO 4217 currency alphabetic code
+\item iso4217n: ISO 4217 currency numeric code
+\item p4.name: Polity IV country name
+\item region: 7 Regions as defined in the World Bank Development Indicators
+\item region23: 23 Regions as used to be in the World Bank Development Indicators (legacy)
+\item un.name.ar: United Nations Arabic country name
+\item un.name.en: United Nations English country name
+\item un.name.es: United Nations Spanish country name
+\item un.name.fr: United Nations French country name
+\item un.name.ru: United Nations Russian country name
+\item un.name.zh: United Nations Chinese country name
+\item un.region.name: United Nations region name
+\item un.region.code: United Nations region code
+\item un.regionintermediate.name: United Nations intermediate region name
+\item un.regionintermediate.code: United Nations intermediate region code
+\item un.regionsub.name: United Nations sub-region name
+\item un.regionsub.code: United Nations sub-region code
+\item wvs.name: World Values Survey numeric code country name
+\item cldr.*: 600+ country name variants from the UNICODE CLDR project.
+Inspect the \code{countrycode::cldr_examples} data.frame for a full list of
+available country names and examples.
 }
 }
 \note{
@@ -86,9 +86,9 @@ The Correlates of War (cow) and Polity 4 (p4) project produce codes in
 country year format. Some countries go through political transitions that
 justify changing codes over time. When building a purely cross-sectional
 conversion dictionary, this forces us to make arbitrary choices with respect
-to some entities (e.g., Western Germany, Vietnam, Serbia). `countrycode`
+to some entities (e.g., Western Germany, Vietnam, Serbia). \code{countrycode}
 includes a reconciled dataset in panel format:
-`countrycode::countrycode_panel`. Instead of converting code, we recommend
+\code{countrycode::countrycode_panel}. Instead of converting code, we recommend
 that users dealing with panel data "left-merge" their data into this panel
 dictionary.
 }

--- a/man/countrycode-package.Rd
+++ b/man/countrycode-package.Rd
@@ -19,8 +19,9 @@ Type ?codelist to get a list of available origin and destination
 codes.
 }
 \references{
-\url{http://arelbundock.com}
-    \url{https://github.com/vincentarelbundock/countrycode}
+\preformatted{\url{http://arelbundock.com}
+\url{https://github.com/vincentarelbundock/countrycode}
+}
 }
 \author{
 Vincent Arel-Bundock \email{vincent.arel-bundock@umontreal.ca}

--- a/man/countrycode.Rd
+++ b/man/countrycode.Rd
@@ -23,7 +23,7 @@ converted (character or factor)}
 quotes ""): type "?codelist" for a list of available codes.}
 
 \item{destination}{Coding scheme of destination (string such as "iso3c"
-enclosed in quotes ""): type `?codelist` for a list of
+enclosed in quotes ""): type \code{?codelist} for a list of
 available codes.}
 
 \item{warn}{Prints unique elements from sourcevar for which no match was found}
@@ -38,7 +38,7 @@ length as sourcevar.}
 \item{custom_dict}{A data frame which supplies a new dictionary to replace
 the built-in country code dictionary. Each column contains a different code
 and must include no duplicates. The data frame format should resemble
-`countrycode::codelist`.  Warning: when `custom_dict` is used, no sanity
+\code{countrycode::codelist}.  Warning: when \code{custom_dict} is used, no sanity
 checks are conducted.}
 
 \item{custom_match}{A named vector which supplies custom origin and
@@ -66,12 +66,12 @@ converting codes. For instance, some countries like Vietnam or Serbia go
 through political transitions that justify changing codes over time. This
 can pose problems when using codes from organizations like CoW or Polity IV,
 which produce codes in country-year format. Instead of converting codes
-using the `countrycode` function, we recommend that users use the
-``countrycode::codelist_panel`` data.frame as a base into which they can
+using the \code{countrycode} function, we recommend that users use the
+\code{countrycode::codelist_panel} data.frame as a base into which they can
 merge their other data. This data.frame includes most relevant code, and is
 already "reconciled" to ensure that each political unit is only represented
-by one row in any given year. From there, it is just a matter of using `R`'s
-`merge` function to combine different datasets which use different codes.
+by one row in any given year. From there, it is just a matter of using \code{R}'s
+\code{merge} function to combine different datasets which use different codes.
 }
 \examples{
 library(countrycode)

--- a/man/countryname.Rd
+++ b/man/countryname.Rd
@@ -11,17 +11,17 @@ countryname(sourcevar, destination = "cldr.short.en", warn = TRUE)
 converted (character or factor)}
 
 \item{destination}{Coding scheme of destination (string such as "iso3c"
-enclosed in quotes ""): type `?codelist` for a list of
+enclosed in quotes ""): type \code{?codelist} for a list of
 available codes.}
 
 \item{warn}{Prints unique elements from sourcevar for which no match was found}
 }
 \description{
 Converts long country names in any language to one of many different country
-code schemes or country names. `countryname` does 2 passes on the data.
+code schemes or country names. \code{countryname} does 2 passes on the data.
 First, it tries to detect variations of country names in many languages
 extracted from the Unicode Common Locale Data Repository. Second, it applies
-`countrycode`'s English regexes to try to match the remaining cases.
+\code{countrycode}'s English regexes to try to match the remaining cases.
 }
 \details{
 Note that the function works with non-ASCII characters. Please see the

--- a/man/countryname_dict.Rd
+++ b/man/countryname_dict.Rd
@@ -4,12 +4,12 @@
 \name{countryname_dict}
 \alias{countryname_dict}
 \title{A dataframe of alternative country names in many languages. Used internally by
-the `countryname` function.}
+the \code{countryname} function.}
 \format{
 dataframe
 }
 \description{
 A dataframe of alternative country names in many languages. Used internally by
-the `countryname` function.
+the \code{countryname} function.
 }
 \keyword{datasets}

--- a/man/guess_field.Rd
+++ b/man/guess_field.Rd
@@ -10,13 +10,13 @@ guess_field(codes, min_similarity = 80)
 \item{codes}{a vector of country codes or country names}
 
 \item{min_similarity}{the function returns all field names where over than
-`min_similarity`% of codes are shared between the supplied vector and the
-`countrycode` dictionary.}
+\code{min_similarity}\% of codes are shared between the supplied vector and the
+\code{countrycode} dictionary.}
 }
 \description{
 Users sometimes do not know what kind of code or field their data contain.
 This function tries to guess by comparing the similarity between a
-user-supplied vector and all the codes included in the `countrycode`
+user-supplied vector and all the codes included in the \code{countrycode}
 dictionary.
 }
 \examples{


### PR DESCRIPTION
and tidy `DESCRIPTION` file (using `usethis::use_tidy_description()`).

Markdown syntax is already used at various places in the documentation but wasn't rendered correctly since the [roxygen2's Markdown support](https://roxygen2.r-lib.org/articles/rd-formatting.html) wasn't turned on.