### PR TITLE
Use dynamic `origin` and `destination` arg matching in `countrycode()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,11 @@ URL: https://vincentarelbundock.github.io/countrycode
 BugReports: https://github.com/vincentarelbundock/countrycode/issues
 Depends:
     R (>= 2.10)
+Imports: 
+    checkmate,
+    rlang,
+    stats,
+    utils
 Suggests:
     testthat,
     tibble,

--- a/R/countrycode-package.R
+++ b/R/countrycode-package.R
@@ -20,3 +20,9 @@
 #' @docType package
 #' @keywords package
 NULL
+
+# Avoid `R CMD check` notes about "undefined" global objects
+utils::globalVariables(names = c("cldr_examples",
+                                 "codelist",
+                                 "codelist_panel",
+                                 "countryname_dict"))

--- a/R/countrycode.R
+++ b/R/countrycode.R
@@ -71,7 +71,7 @@
 #' hosted on github. We use a shortened URL to load it.
 #' cd <- 'https://bit.ly/2ToSrFv'
 #' cd <- read.csv(cd)
-#' countrycode(c('AL', 'AK'), 'abbreviation', 'state', 
+#' countrycode(c('AL', 'AK'), 'abbreviation', 'state',
 #'             custom_dict = cd)
 #' countrycode(c('Alabama', 'North Dakota'), 'state.regex', 'state',
 #'             custom_dict = cd, origin_regex = TRUE)

--- a/R/countrycode.R
+++ b/R/countrycode.R
@@ -115,7 +115,7 @@ countrycode <- function(sourcevar, origin, destination, warn = TRUE, nomatch = N
     }
 
     # Allow tibbles as conversion dictionary
-    if('tbl_df' %in% class(dictionary)){ # allow tibble
+    if ('tbl_df' %in% class(dictionary)) { # allow tibble
         dictionary <- as.data.frame(dictionary)
     }
 
@@ -143,16 +143,16 @@ countrycode <- function(sourcevar, origin, destination, warn = TRUE, nomatch = N
         stop('Destination code not supported by countrycode or present in the user-supplied custom_dict.')
     }
 
-    if(!inherits(dictionary, "data.frame")) {
+    if (!inherits(dictionary, "data.frame")) {
         stop("Dictionary must be a data frame or tibble with codes as columns.")
     }
 
-    if(!destination %in% colnames(dictionary)){
+    if (!destination %in% colnames(dictionary)) {
         stop("Destination code must correpond to a column name in the dictionary data frame.")
     }
 
     dups = any(duplicated(stats::na.omit(dictionary[, origin])))
-    if(dups){
+    if (dups) {
         stop("Countrycode cannot accept dictionaries with duplicated origin codes")
     }
 
@@ -160,8 +160,8 @@ countrycode <- function(sourcevar, origin, destination, warn = TRUE, nomatch = N
     origin_vector <- sourcevar
 
     # Case-insensitive matching
-    if(is.null(custom_dict)){ # only for built-in dictionary
-        if(inherits(origin_vector, 'character') & !grepl('country', origin)){
+    if (is.null(custom_dict)) { # only for built-in dictionary
+        if (inherits(origin_vector, 'character') & !grepl('country', origin)) {
             origin_vector = toupper(origin_vector)
         }
     }
@@ -233,7 +233,7 @@ countrycode <- function(sourcevar, origin, destination, warn = TRUE, nomatch = N
         } else if (class(sourcevar)[1] == "factor" & class(destination_vector)[1] == "character") {
             destination_vector[idx] <- as.character(sourcevar[idx])
         } else {
-            warning("The origin and destination codes are not of the same
+            warning("The `origin` and `destination` codes are not of the same
                     class. Filling-in bad matches with NA instead.")
         }
     } else if ((length(nomatch) == 1) & is.na(nomatch)) { # NA
@@ -247,17 +247,17 @@ countrycode <- function(sourcevar, origin, destination, warn = TRUE, nomatch = N
     }
 
     # Warnings
-    if(warn){
+    if (warn) {
         badmatch <- sort(unique(origin_vector[is.na(destination_vector)]))
         badmatch <- badmatch[!badmatch %in% names(custom_match)]  # do not report <NA>'s that were set explicitly by custom_match
-        if(length(badmatch) > 0){
-            warning("Some values were not matched unambiguously: ", paste(badmatch, collapse=", "), "\n")
+        if (length(badmatch) > 0) {
+            warning("Some values were not matched unambiguously: ", paste(badmatch, collapse = ", "), "\n")
         }
-        if(origin_regex){
-           if(length(destination_list) > 0){
-               destination_list <- lapply(destination_list, function(k) paste(k, collapse=','))
+        if (origin_regex) {
+           if (length(destination_list) > 0) {
+               destination_list <- lapply(destination_list, function(k) paste(k, collapse = ','))
                destination_list <- sort(unique(do.call('c', destination_list)))
-               warning("Some strings were matched more than once, and therefore set to <NA> in the result: ", paste(destination_list, collapse="; "), "\n")
+               warning("Some strings were matched more than once, and therefore set to <NA> in the result: ", paste(destination_list, collapse = "; "), "\n")
            }
         }
     }

--- a/R/countryname.R
+++ b/R/countryname.R
@@ -7,7 +7,7 @@
 #' `countrycode`'s English regexes to try to match the remaining cases.
 #'
 #' Note that the function works with non-ASCII characters. Please see the
-#' Github page for examples. 
+#' Github page for examples.
 #'
 #' @param sourcevar Vector which contains the codes or country names to be
 #' converted (character or factor)
@@ -26,26 +26,26 @@
 #' }
 #'
 countryname <- function(sourcevar, destination = 'cldr.short.en', warn = TRUE) {
-    
+
     out <- countrycode(sourcevar = sourcevar,
                        origin = 'country.name.alt',
                        destination = 'country.name.en',
                        custom_dict = countryname_dict,
                        warn = FALSE)
-    
+
     idx <- is.na(out)
-    out[idx] <- countrycode(sourcevar = sourcevar[idx], 
-                            origin = 'country.name.en', 
-                            destination = 'country.name.en', 
+    out[idx] <- countrycode(sourcevar = sourcevar[idx],
+                            origin = 'country.name.en',
+                            destination = 'country.name.en',
                             warn = warn)
-    
+
     if (destination != 'country.name.en') {
       out <- countrycode(sourcevar = out,
-                         origin = 'country.name.en', 
+                         origin = 'country.name.en',
                          destination = destination,
                          custom_dict = codelist,
                          warn = warn)
     }
-    
+
     return(out)
 }

--- a/R/countryname.R
+++ b/R/countryname.R
@@ -30,7 +30,7 @@ countryname <- function(sourcevar, destination = 'cldr.short.en', warn = TRUE) {
     out <- countrycode(sourcevar = sourcevar,
                        origin = 'country.name.alt',
                        destination = 'country.name.en',
-                       custom_dict = countrycode::countryname_dict,
+                       custom_dict = countryname_dict,
                        warn = FALSE)
     
     idx <- is.na(out)
@@ -43,7 +43,7 @@ countryname <- function(sourcevar, destination = 'cldr.short.en', warn = TRUE) {
       out <- countrycode(sourcevar = out,
                          origin = 'country.name.en', 
                          destination = destination,
-                         custom_dict = countrycode::codelist, 
+                         custom_dict = codelist,
                          warn = warn)
     }
     

--- a/R/guess_field.R
+++ b/R/guess_field.R
@@ -28,7 +28,7 @@ guess_field <- function(codes, min_similarity = 80) {
   x <- unique(codes)
 
   match_percentage <-
-    sapply(countrycode::codelist, function(code) {
+    sapply(codelist, function(code) {
       sum(x %in% code) / length(x) * 100
     })
 

--- a/dictionary/get_countryname_dict.R
+++ b/dictionary/get_countryname_dict.R
@@ -15,7 +15,7 @@ ambiguous <- c('the Holy Land', 'Nigeri', 'Virgin Islands', 'Виргин ара
              clean_string
 
 # countrycode::codelist reshape
-dat <- countrycode::codelist %>% 
+dat <- codelist %>%
        select(countryname = country.name.en, matches('name')) %>%
        select(-matches('region|regex')) %>%
        pivot_longer(-countryname, values_to = 'alternative') %>%

--- a/dictionary/get_countryname_dict.R
+++ b/dictionary/get_countryname_dict.R
@@ -11,7 +11,7 @@ clean_string <- function(x) {
 
 ambiguous <- c('the Holy Land', 'Nigeri', 'Virgin Islands', 'Виргин аралдары',
                'Виргинийн гӀайренаш', 'Виргинские о-ва', "ﻞﺗﻮﻧی", 'Iberia',
-               'Indien', 'Thule', 'Micronesia', 'Saint Martin') %>% 
+               'Indien', 'Thule', 'Micronesia', 'Saint Martin') %>%
              clean_string
 
 # countrycode::codelist reshape
@@ -25,7 +25,7 @@ dat <- codelist %>%
        mutate(countryname = countrycode(countryname, 'country.name', 'country.name.en')) %>%
        filter(nchar(alternative) > 4,
               !alternative %in% ambiguous,
-              !countryname %in% ambiguous, 
+              !countryname %in% ambiguous,
               !duplicated(alternative), # "لتونی"matches both Latvia and Lithuania!?!
               (countryname != 'North Korea') | (alternative != 'Corée'),
               (countryname != 'North Korea') | (alternative != 'Korea'),

--- a/man/countrycode.Rd
+++ b/man/countrycode.Rd
@@ -6,8 +6,12 @@
 \usage{
 countrycode(
   sourcevar,
-  origin,
-  destination,
+  origin = c("cctld", "country.name", "country.name.de", "cowc", "cown", "dhs", "ecb",
+    "eurostat", "fao", "fips", "gaul", "genc2c", "genc3c", "genc3n", "gwc", "gwn", "imf",
+    "ioc", "iso2c", "iso3c", "iso3n", "p4c", "p4n", "un", "un_m49", "unicode.symbol",
+    "unpd", "vdem", "wb", "wb_api2c", "wb_api3c", "wvs", "country.name.en.regex",
+    "country.name.de.regex"),
+  destination = colnames(codelist),
   warn = TRUE,
   nomatch = NA,
   custom_dict = NULL,

--- a/man/countrycode.Rd
+++ b/man/countrycode.Rd
@@ -95,7 +95,7 @@ countrycode(c('United States', 'Algeria'), 'country.name', 'iso3c',
 hosted on github. We use a shortened URL to load it.
 cd <- 'https://bit.ly/2ToSrFv'
 cd <- read.csv(cd)
-countrycode(c('AL', 'AK'), 'abbreviation', 'state', 
+countrycode(c('AL', 'AK'), 'abbreviation', 'state',
             custom_dict = cd)
 countrycode(c('Alabama', 'North Dakota'), 'state.regex', 'state',
             custom_dict = cd, origin_regex = TRUE)

--- a/tests/testthat/test-codelist.R
+++ b/tests/testthat/test-codelist.R
@@ -1,6 +1,6 @@
 
-cs <- countrycode::codelist
-pan <- countrycode::codelist_panel
+cs <- codelist
+pan <- codelist_panel
 
 dest <- c('year', 'ar5', 'continent', 'currency', 'eu28', 'eurocontrol_pru',
           'eurocontrol_statfor', 'icao', 'icao.region', 'iso4217c',


### PR DESCRIPTION
This gives way better error messages, cf. [`rlang::arg_match()`](https://rlang.r-lib.org/reference/arg_match.html).

Plus some cosmetic changes.