### PR TITLE
Use roxygen2 to generate package documentation

### DIFF
--- a/countrycode.Rproj
+++ b/countrycode.Rproj
@@ -18,3 +18,4 @@ StripTrailingWhitespace: Yes
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace


### PR DESCRIPTION
This ensures RStudio uses roxygen2 to generate the package documentation.