### PR TITLE
Update check-standard.yaml

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -29,7 +29,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-pandoc@v2
 


### PR DESCRIPTION
`actions/checkout` is now at [v3](https://github.com/actions/checkout)

This should stop all the "Node.js 12 actions are deprecated." warnings

(also used/recommended by current `r-lib/actions` `check-standard.yaml` [example](https://github.com/r-lib/actions/blob/v2/examples/check-standard.yaml))