### PR TITLE
Faster conversion from all codes (not country names)

### DIFF
--- a/R/countrycode.R
+++ b/R/countrycode.R
@@ -199,11 +199,11 @@ countrycode <- function(sourcevar, origin, destination, warn = TRUE, nomatch = N
         # unicode.symbol breaks uppercase on Windows R-devel 2022-02-02; rejected by CRAN
         if(inherits(origin_vector, 'character') & !grepl('country|unicode.symbol', origin)){
             # only apply toupper() on unique values and match after.
-            # much faster than applying toupper() on the whole vector when vector is very large
+            # much faster than applying toupper() on the whole vector
+            # when vector is very large
             uniques = unique(origin_vector)
             uppercase = toupper(uniques)
-            names(uppercase) = uniques
-            origin_vector = unname(uppercase[match(origin_vector, names(uppercase))])
+            origin_vector = unname(uppercase[match(origin_vector, uniques)])
         }
     }
 

--- a/R/countrycode.R
+++ b/R/countrycode.R
@@ -201,9 +201,9 @@ countrycode <- function(sourcevar, origin, destination, warn = TRUE, nomatch = N
             # only apply toupper() on unique values and match after.
             # much faster than applying toupper() on the whole vector
             # when vector is very large
-            uniques = unique(origin_vector)
-            uppercase = toupper(uniques)
-            origin_vector = unname(uppercase[match(origin_vector, uniques)])
+            uniques <- unique(origin_vector)
+            uppercase <- toupper(uniques)
+            origin_vector <- unname(uppercase[match(origin_vector, uniques)])
         }
     }
 

--- a/R/countrycode.R
+++ b/R/countrycode.R
@@ -198,7 +198,12 @@ countrycode <- function(sourcevar, origin, destination, warn = TRUE, nomatch = N
     if(is.null(custom_dict)){ # only for built-in dictionary
         # unicode.symbol breaks uppercase on Windows R-devel 2022-02-02; rejected by CRAN
         if(inherits(origin_vector, 'character') & !grepl('country|unicode.symbol', origin)){
-            origin_vector = toupper(origin_vector)
+            # only apply toupper() on unique values and match after.
+            # much faster than applying toupper() on the whole vector when vector is very large
+            uniques = unique(origin_vector)
+            uppercase = toupper(uniques)
+            names(uppercase) = uniques
+            origin_vector = unname(uppercase[match(origin_vector, names(uppercase))])
         }
     }
 


### PR DESCRIPTION
Simple speedup: only apply `toupper()` on unique strings and then match the original vector on these. Not crucial but it saves a couple of seconds every time I use `countrycode()` in this direction. It uses a bit more memory though so whatever you prefer.

``` r
library(bench)

out <- cross::run(
  pkgs = c("vincentarelbundock/countrycode", "etiennebacher/countrycode@speedup-iso"),
  ~{
    library(countrycode)
    
    test <- data.frame(
      grp1 = sample(codelist$iso3c, 1e7, TRUE),
      grp2 = sample(codelist$cowc, 1e7, TRUE),
      grp3 = sample(codelist$eurostat, 1e7, TRUE)
    )
    
    bench::mark(
      countrycode(test$grp1, "iso3c", "country.name"),
      countrycode(test$grp2, "cowc", "country.name"),
      countrycode(test$grp3, "eurostat", "country.name"),
      iterations = 10,
      check = FALSE
    )
  }
)

tidyr::unnest(out, result) |>
  dplyr::select(pkg, expression, median, mem_alloc) |>
  dplyr::mutate(pkg = ifelse(grepl("vincent", pkg), "main", "fork")) |> 
  dplyr::arrange(expression, desc(pkg))
#> # A tibble: 6 × 4
#>   pkg   expression                                              median mem_alloc
#>   <chr> <bch:expr>                                            <bch:tm> <bch:byt>
#> 1 main  "countrycode(test$grp1, \"iso3c\", \"country.name\")"    3.34s  738.81MB
#> 2 fork  "countrycode(test$grp1, \"iso3c\", \"country.name\")" 991.98ms 1019.44MB
#> 3 main  "countrycode(test$grp2, \"cowc\", \"country.name\")"     3.03s  772.15MB
#> 4 fork  "countrycode(test$grp2, \"cowc\", \"country.name\")"  989.79ms    1.03GB
#> 5 main  "countrycode(test$grp3, \"eurostat\", \"country.name…    3.38s  739.88MB
#> 6 fork  "countrycode(test$grp3, \"eurostat\", \"country.name… 832.43ms 1020.47MB
```







