### PR TITLE
uopdate ISO4217 scraper

### DIFF
--- a/dictionary/data_iso4217.csv
+++ b/dictionary/data_iso4217.csv
@@ -53,7 +53,7 @@ Congo - Brazzaville,CFA Franc BEAC,XAF,950
 Cook Islands,New Zealand Dollar,NZD,554
 Costa Rica,Costa Rican Colon,CRC,188
 Côte d’Ivoire,CFA Franc BCEAO,XOF,952
-Croatia,Kuna,HRK,191
+Croatia,Euro,EUR,978
 Cuba,Cuban Peso,CUP,192
 Curaçao,Netherlands Antillean Guilder,ANG,532
 Cyprus,Euro,EUR,978
@@ -196,7 +196,7 @@ Saudi Arabia,Saudi Riyal,SAR,682
 Senegal,CFA Franc BCEAO,XOF,952
 Serbia,Serbian Dinar,RSD,941
 Seychelles,Seychelles Rupee,SCR,690
-Sierra Leone,Leone,SLL,694
+Sierra Leone,Leone,SLE,925
 Singapore,Singapore Dollar,SGD,702
 Sint Maarten,Netherlands Antillean Guilder,ANG,532
 Slovakia,Euro,EUR,978
@@ -223,7 +223,6 @@ Tokelau,New Zealand Dollar,NZD,554
 Tonga,Pa’anga,TOP,776
 Trinidad & Tobago,Trinidad and Tobago Dollar,TTD,780
 Tunisia,Tunisian Dinar,TND,788
-Turkey,Turkish Lira,TRY,949
 Turkmenistan,Turkmenistan New Manat,TMT,934
 Turks & Caicos Islands,US Dollar,USD,840
 Tuvalu,Australian Dollar,AUD,36

--- a/dictionary/get_iso4217.R
+++ b/dictionary/get_iso4217.R
@@ -1,6 +1,6 @@
 source(here::here('dictionary/utilities.R'))
 
-url <- 'https://www.currency-iso.org/dam/downloads/lists/list_one.xls'
+url <- 'https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-one.xls'
 download.file(url, tmpxls <- tempfile(fileext = '.xls'), quiet = TRUE)
 
 read_excel(tmpxls, skip = 3) %>%
@@ -18,6 +18,7 @@ read_excel(tmpxls, skip = 3) %>%
   filter(!(country == "Panama" & Currency == "US Dollar")) %>%
   filter(!(country == "Uruguay" & Currency == "Unidad Previsional")) %>%
   filter(!(country == "Venezuela" & `Alphabetic Code` == "VES")) %>%
+  filter(!(country == "Sierra Leone" & `Alphabetic Code` == "SLL")) %>%
   mutate(`Numeric Code` = as.numeric(`Numeric Code`)) %>%
   select(country, currency = Currency, iso4217c = `Alphabetic Code`,
          iso4217n = `Numeric Code`) %>%


### PR DESCRIPTION
Caution: changes the CSV data...

- Croatia (apparently) is now using the Euro
- Sierra Leone [has a new currency](https://en.wikipedia.org/wiki/Sierra_Leonean_leone)
- Türkiye is now spelled `TÜRKİYE` in this data, so it is currently dropped as the current version of `countrycode` does not recognize it (see #347)