### PR TITLE
Redistributed countries from ESRA into ECAC

### DIFF
--- a/dictionary/data_aviation.csv
+++ b/dictionary/data_aviation.csv
@@ -1,7 +1,7 @@
 country,ar5,eurocontrol_statfor,eurocontrol_pru
 Afghanistan,ASIA,Asia/Pacific,Asia
-Åland Islands,OECD1990,ESRA North-West,Eurocontrol
-Albania,EIT,ESRA East,Eurocontrol
+Åland Islands,OECD1990,ECAC North-East,Eurocontrol
+Albania,EIT,ECAC South-East,Eurocontrol
 Algeria,MAF,North-Africa,Africa
 American Samoa,ASIA,Asia/Pacific,Asia
 Andorra,OECD1990,"",""
@@ -10,30 +10,30 @@ Anguilla,LAM,Mid-Atlantic,Southern America
 Antarctica,LAM,Asia/Pacific,Asia
 Antigua and Barbuda,LAM,Mid-Atlantic,Southern America
 Argentina,LAM,South-Atlantic,Southern America
-Armenia,EIT,Other Europe,Eurocontrol
+Armenia,EIT,ECAC South-East,Eurocontrol
 Aruba,LAM,Mid-Atlantic,Southern America
 Australia,OECD1990,Asia/Pacific,Asia
-Austria,OECD1990,ESRA North-West,Eurocontrol
-Azerbaijan,EIT,Other Europe,Asia
+Austria,OECD1990,ECAC North-West,Eurocontrol
+Azerbaijan,EIT,ECAC South-East,Asia
 Bahamas,LAM,Mid-Atlantic,Southern America
 Bahrain,MAF,Middle-East,Middle East
 Bangladesh,ASIA,Asia/Pacific,Asia
 Barbados,LAM,Mid-Atlantic,Southern America
 Belarus,EIT,Other Europe,Asia
-Belgium,OECD1990,ESRA North-West,Eurocontrol
+Belgium,OECD1990,ECAC North-West,Eurocontrol
 Belize,LAM,Mid-Atlantic,Southern America
 Benin,MAF,Southern Africa,Africa
 Bermuda,LAM,Mid-Atlantic,Southern America
 Bhutan,ASIA,Asia/Pacific,Asia
 Bolivia (Plurinational State of),LAM,South-Atlantic,Southern America
 "Bonaire, Sint Eustatius and Saba","",Mid-Atlantic,Southern America
-Bosnia and Herzegovina,EIT,ESRA East,Eurocontrol
+Bosnia and Herzegovina,EIT,ECAC South-East,Eurocontrol
 Botswana,MAF,Southern Africa,Africa
 Bouvet Island,LAM,"",""
 Brazil,LAM,South-Atlantic,Southern America
 British Indian Ocean Territory,ASIA,"",""
 Brunei Darussalam,ASIA,Asia/Pacific,Asia
-Bulgaria,EIT,ESRA East,Eurocontrol
+Bulgaria,EIT,ECAC South-East,Eurocontrol
 Burkina Faso,MAF,Southern Africa,Africa
 Burundi,MAF,Southern Africa,Africa
 Cabo Verde,MAF,Southern Africa,Africa
@@ -53,14 +53,14 @@ Congo,MAF,Southern Africa,Africa
 Cook Islands,ASIA,Asia/Pacific,Asia
 Costa Rica,LAM,Mid-Atlantic,Southern America
 Côte D'Ivoire,MAF,Southern Africa,Africa
-Croatia,EIT,ESRA East,Eurocontrol
+Croatia,EIT,ECAC South-East,Eurocontrol
 Cuba,LAM,Mid-Atlantic,Southern America
 Curacao,LAM,Mid-Atlantic,Southern America
-Cyprus,EIT,ESRA Mediterranean,Eurocontrol
-Czech Republic,EIT,ESRA East,Eurocontrol
+Cyprus,EIT,ECAC South-East,Eurocontrol
+Czech Republic,EIT,ECAC North-East,Eurocontrol
 Democratic People's Republic of Korea,ASIA,Asia/Pacific,Asia
 Democratic Republic of the Congo,MAF,Southern Africa,Africa
-Denmark,OECD1990,ESRA North-West,Eurocontrol
+Denmark,OECD1990,ECAC North-West,Eurocontrol
 Djibouti,MAF,Southern Africa,Africa
 Dominica,LAM,Mid-Atlantic,Southern America
 Dominican Republic,LAM,Mid-Atlantic,Southern America
@@ -69,30 +69,30 @@ Egypt,MAF,North-Africa,Middle East
 El Salvador,LAM,Mid-Atlantic,Southern America
 Equatorial Guinea,MAF,Southern Africa,Africa
 Eritrea,MAF,Southern Africa,Africa
-Estonia,EIT,Other Europe,Eurocontrol
+Estonia,EIT,ECAC North-East,Eurocontrol
 Ethiopia,MAF,Southern Africa,Africa
 Falkland Islands (Malvinas),LAM,South-Atlantic,Southern America
-Faroe Islands,OECD1990,ESRA North-West,Eurocontrol
+Faroe Islands,OECD1990,ECAC-Oceanic,Eurocontrol
 Fiji,ASIA,Asia/Pacific,Asia
-Finland,OECD1990,ESRA North-West,Eurocontrol
-France,OECD1990,ESRA North-West,Eurocontrol
+Finland,OECD1990,ECAC North-East,Eurocontrol
+France,OECD1990,ECAC North-West,Eurocontrol
 French Guiana,LAM,South-Atlantic,Southern America
 French Polynesia,ASIA,Asia/Pacific,Asia
 French Southern Territories,LAM,"",""
 Gabon,MAF,Southern Africa,Africa
 Gambia (Islamic Republic of the),MAF,Southern Africa,Africa
-Georgia,EIT,Other Europe,Eurocontrol
-German Democratic Republic,"",ESRA North-West,Eurocontrol
-Germany,OECD1990,ESRA North-West,Eurocontrol
+Georgia,EIT,ECAC South-East,Eurocontrol
+German Democratic Republic,"",ECAC North-West,Eurocontrol
+Germany,OECD1990,ECAC North-West,Eurocontrol
 Ghana,MAF,Southern Africa,Africa
-Gibraltar,OECD1990,Other Europe,Eurocontrol
-Greece,OECD1990,ESRA Mediterranean,Eurocontrol
+Gibraltar,OECD1990,ECAC South-West,Eurocontrol
+Greece,OECD1990,ECAC South-East,Eurocontrol
 Greenland,OECD1990,Other Europe,Northern America
 Grenada,LAM,Mid-Atlantic,Southern America
 Guadeloupe,LAM,Mid-Atlantic,Southern America
 Guam,OECD1990,Asia/Pacific,Asia
 Guatemala,LAM,Mid-Atlantic,Southern America
-Guernsey,OECD1990,ESRA North-West,Eurocontrol
+Guernsey,OECD1990,ECAC North-West,Eurocontrol
 Guinea,MAF,Southern Africa,Africa
 Guinea Bissau,MAF,Southern Africa,Africa
 Guyana,MAF,South-Atlantic,Southern America
@@ -101,19 +101,19 @@ Heard Island and McDonald Islands,ASIA,"",""
 Holy See (Vatican City State),OECD1990,"",""
 Honduras,LAM,Mid-Atlantic,Southern America
 Hong Kong,"",Asia/Pacific,China
-Hungary,EIT,ESRA East,Eurocontrol
-Iceland,OECD1990,Other Europe,Northern America
+Hungary,EIT,ECAC South-East,Eurocontrol
+Iceland,OECD1990,ECAC-Oceanic,Northern America
 India,ASIA,Asia/Pacific,Asia
 Indonesia,ASIA,Asia/Pacific,Asia
 Iran (Islamic Republic of),MAF,Middle-East,Middle East
 Iraq,MAF,Middle-East,Middle East
-Ireland,OECD1990,ESRA North-West,Eurocontrol
-Isle of Man,OECD1990,ESRA North-West,Eurocontrol
+Ireland,OECD1990,ECAC North-West,Eurocontrol
+Isle of Man,OECD1990,ECAC North-West,Eurocontrol
 Israel,MAF,Middle-East,Middle East
-Italy,OECD1990,ESRA Mediterranean,Eurocontrol
+Italy,OECD1990,ECAC South-East,Eurocontrol
 Jamaica,LAM,Mid-Atlantic,Southern America
 Japan,OECD1990,Asia/Pacific,Asia
-Jersey,OECD1990,ESRA North-West,Eurocontrol
+Jersey,OECD1990,ECAC North-West,Eurocontrol
 Jordan,MAF,Middle-East,Middle East
 Kazakhstan,EIT,Asia/Pacific,Asia
 Kenya,MAF,Asia/Pacific,Africa
@@ -121,21 +121,21 @@ Kiribati,ASIA,Asia/Pacific,Asia
 Kuwait,MAF,Middle-East,Middle East
 Kyrgyzstan,EIT,Asia/Pacific,Asia
 Lao People's Democratic Republic,ASIA,Asia/Pacific,Asia
-Latvia,EIT,Other Europe,Eurocontrol
+Latvia,EIT,ECAC North-East,Eurocontrol
 Lebanon,MAF,Middle-East,Middle East
 Lesotho,MAF,Southern Africa,Africa
 Liberia,MAF,Southern Africa,Africa
 Libya,MAF,North-Africa,Africa
-Liechtenstein,OECD1990,ESRA North-West,Eurocontrol
-Lithuania,EIT,Other Europe,Eurocontrol
-Luxembourg,OECD1990,ESRA North-West,Eurocontrol
+Liechtenstein,OECD1990,ECAC North-West,Eurocontrol
+Lithuania,EIT,ECAC North-East,Eurocontrol
+Luxembourg,OECD1990,ECAC North-West,Eurocontrol
 Macao,"",Asia/Pacific,China
 Madagascar,MAF,Southern Africa,Africa
 Malawi,MAF,Southern Africa,Africa
 Malaysia,MAF,Asia/Pacific,Asia
 Maldives,ASIA,Asia/Pacific,Asia
 Mali,MAF,Southern Africa,Africa
-Malta,EIT,ESRA Mediterranean,Eurocontrol
+Malta,EIT,ECAC South-East,Eurocontrol
 Marshall Islands,ASIA,Asia/Pacific,Asia
 Martinique,LAM,Mid-Atlantic,Southern America
 Mauritania,MAF,Southern Africa,Africa
@@ -143,9 +143,9 @@ Mauritius,MAF,Southern Africa,Africa
 Mayotte,MAF,Southern Africa,Africa
 Mexico,LAM,Mid-Atlantic,Southern America
 Micronesia (Federated States of),ASIA,Asia/Pacific,Asia
-Monaco,OECD1990,ESRA North-West,Eurocontrol
+Monaco,OECD1990,ECAC North-West,Eurocontrol
 Mongolia,ASIA,Asia/Pacific,Asia
-Montenegro,EIT,ESRA East,Eurocontrol
+Montenegro,EIT,ECAC South-East,Eurocontrol
 Montserrat,LAM,Mid-Atlantic,Southern America
 Morocco,MAF,North-Africa,Africa
 Mozambique,MAF,Southern Africa,Africa
@@ -153,7 +153,7 @@ Myanmar,ASIA,Asia/Pacific,Asia
 Namibia,MAF,Southern Africa,Africa
 Nauru,ASIA,Asia/Pacific,Asia
 Nepal,ASIA,Asia/Pacific,Asia
-Netherlands,OECD1990,ESRA North-West,Eurocontrol
+Netherlands,OECD1990,ECAC North-West,Eurocontrol
 Netherlands Antilles,LAM,Mid-Atlantic,Southern America
 New Caledonia,ASIA,Asia/Pacific,Asia
 New Zealand,OECD1990,Asia/Pacific,Asia
@@ -163,7 +163,7 @@ Nigeria,MAF,Southern Africa,Africa
 Niue,ASIA,Asia/Pacific,Asia
 Norfolk Island,ASIA,Asia/Pacific,Asia
 Northern Mariana Islands,ASIA,Asia/Pacific,Asia
-Norway,MAF,ESRA North-West,Eurocontrol
+Norway,MAF,ECAC North-East,Eurocontrol
 Oman,"",Middle-East,Middle East
 Pakistan,ASIA,Asia/Pacific,Asia
 Palau,ASIA,Asia/Pacific,Asia
@@ -174,14 +174,14 @@ Paraguay,LAM,South-Atlantic,Southern America
 Peru,LAM,South-Atlantic,Southern America
 Philippines,ASIA,Asia/Pacific,Asia
 Pitcairn,ASIA,"",""
-Poland,EIT,ESRA East,Eurocontrol
-Portugal,OECD1990,ESRA Mediterranean,Eurocontrol
+Poland,EIT,ECAC North-East,Eurocontrol
+Portugal,OECD1990,ECAC South-West,Eurocontrol
 Puerto Rico,LAM,Mid-Atlantic,Southern America
 Qatar,MAF,Middle-East,Middle East
 Republic of Korea,"",Asia/Pacific,Asia
-Republic of Moldova,EIT,ESRA East,Eurocontrol
+Republic of Moldova,EIT,ECAC South-East,Eurocontrol
 Reunion,MAF,Southern Africa,Africa
-Romania,EIT,ESRA East,Eurocontrol
+Romania,EIT,ECAC South-East,Eurocontrol
 Russian Federation,EIT,Other Europe,Russia
 Rwanda,MAF,Southern Africa,Africa
 Saint Barthelemy,"",Mid-Atlantic,Southern America
@@ -189,54 +189,54 @@ Saint Barthelemy,"",Mid-Atlantic,Southern America
 Saint Kitts and Nevis,LAM,Mid-Atlantic,Southern America
 Saint Lucia,LAM,Mid-Atlantic,Southern America
 Saint Martin (French part),"",Mid-Atlantic,Southern America
-Saint Pierre and Miquelon,OECD1990,ESRA North-West,Northern America
+Saint Pierre and Miquelon,OECD1990,North Atlantic,Northern America
 Saint Vincent and the Grenadines,LAM,Mid-Atlantic,Southern America
 Samoa,ASIA,Asia/Pacific,Asia
 San Marino,OECD1990,"",""
 Sao Tome and Principe,MAF,Southern Africa,Africa
 Saudi Arabia,MAF,Middle-East,Middle East
 Senegal,MAF,"",""
-Serbia,EIT,ESRA East,Eurocontrol
+Serbia,EIT,ECAC South-East,Eurocontrol
 Seychelles,MAF,Southern Africa,Africa
 Sierra Leone,MAF,Southern Africa,Africa
 Singapore,ASIA,Asia/Pacific,Asia
 Sint Maarten (Dutch part),LAM,Mid-Atlantic,Southern America
-Slovakia,EIT,ESRA East,Eurocontrol
-Slovenia,EIT,ESRA East,Eurocontrol
+Slovakia,EIT,ECAC North-East,Eurocontrol
+Slovenia,EIT,ECAC South-East,Eurocontrol
 Solomon Islands,ASIA,Asia/Pacific,Asia
 Somalia,MAF,Southern Africa,Africa
 Somaliland,MAF,Southern Africa,Africa
 South Africa,MAF,Southern Africa,Africa
 South Georgia and the South Sandwich Islands,LAM,"",""
 South Sudan,MAF,Southern Africa,Africa
-Spain,OECD1990,ESRA Mediterranean,Eurocontrol
+Spain,OECD1990,ECAC South-West,Eurocontrol
 Sri Lanka,ASIA,Asia/Pacific,Asia
 Sudan,MAF,Southern Africa,Africa
 Suriname,LAM,South-Atlantic,Southern America
-Svalbard and Jan Mayen,OECD1990,ESRA North-West,Eurocontrol
+Svalbard and Jan Mayen,OECD1990,ECAC-Oceanic,Eurocontrol
 Swaziland,MAF,Southern Africa,Africa
-Sweden,OECD1990,ESRA North-West,Eurocontrol
-Switzerland,OECD1990,ESRA North-West,Eurocontrol
+Sweden,OECD1990,ECAC North-East,Eurocontrol
+Switzerland,OECD1990,ECAC North-West,Eurocontrol
 Syrian Arab Republic,MAF,Middle-East,Middle East
 "Taiwan, Province of China",ASIA,Asia/Pacific,Asia
 Tajikistan,EIT,Asia/Pacific,Asia
 Thailand,ASIA,Asia/Pacific,Asia
-The former Yugoslav Republic of Macedonia,EIT,ESRA East,Eurocontrol
+The former Yugoslav Republic of Macedonia,EIT,ECAC South-East,Eurocontrol
 Timor-Leste,ASIA,Asia/Pacific,Asia
 Togo,MAF,Southern Africa,Africa
 Tokelau,ASIA,"",""
 Tonga,MAF,Asia/Pacific,Asia
 Trinidad and Tobago,LAM,Mid-Atlantic,Southern America
 Tunisia,MAF,North-Africa,Africa
-Turkey,OECD1990,ESRA Mediterranean,Eurocontrol
+Turkey,OECD1990,ECAC South-East,Eurocontrol
 Turkmenistan,EIT,Asia/Pacific,Asia
 Turks and Caicos Islands,LAM,Mid-Atlantic,Southern America
 Tuvalu,ASIA,Asia/Pacific,Asia
 Uganda,MAF,Southern Africa,Africa
-Ukraine,EIT,ESRA East,Eurocontrol
+Ukraine,EIT,ECAC North-East,Eurocontrol
 United Arab Emirates,MAF,Middle-East,Middle East
 United Arab Republic,MAF,Middle-East,Middle East
-United Kingdom of Great Britain and Northern Ireland,OECD1990,ESRA North-West,Eurocontrol
+United Kingdom of Great Britain and Northern Ireland,OECD1990,ECAC North-West,Eurocontrol
 United Republic of Tanzania,MAF,Southern Africa,Africa
 United States Minor Outlying Islands,ASIA,Asia/Pacific,Asia
 United States of America,OECD1990,North Atlantic,Northern America


### PR DESCRIPTION
ESRA is deprecated and has to be replaced by ECAC. 
https://www.eurocontrol.int/sites/default/files/2020-11/eurocontrol-forecast-2020-2024-region-definition.pdf

Updated data_aviation.csv